### PR TITLE
Add the used grunnbeløp on the Result for prosperity

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/Grunnlag.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/Grunnlag.kt
@@ -56,13 +56,14 @@ class Grunnlag(
                 ?: throw NoResultException("Ingen resultat for grunnlagsberegning")
 
         val grunnlagResultat = GrunnlagResultat(
-            ulidGenerator.nextULID(),
-            ulidGenerator.nextULID(),
-            REGELIDENTIFIKATOR,
-            resultat.avkortet,
-            resultat.uavkortet,
-            resultat.beregningsregel,
-            resultat.harAvkortet
+            sporingsId = ulidGenerator.nextULID(),
+            subsumsjonsId = ulidGenerator.nextULID(),
+            regelidentifikator = REGELIDENTIFIKATOR,
+            avkortetGrunnlag = resultat.avkortet,
+            uavkortetGrunnlag = resultat.uavkortet,
+            beregningsregel = resultat.beregningsregel,
+            harAvkortet = resultat.harAvkortet,
+            grunnbeløpBrukt = fakta.gjeldendeGrunnbeløp.verdi
         )
 
         createInntektPerioder(fakta)?.apply {

--- a/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/GrunnlagResultat.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/GrunnlagResultat.kt
@@ -10,17 +10,19 @@ data class GrunnlagResultat(
     val avkortetGrunnlag: BigDecimal,
     val uavkortetGrunnlag: BigDecimal,
     val beregningsregel: String,
-    val harAvkortet: Boolean
+    val harAvkortet: Boolean,
+    val grunnbeløpBrukt: BigDecimal
 ) {
 
     companion object {
-        val SPORINGSID = "sporingsId"
-        val SUBSUMSJONSID = "subsumsjonsId"
-        val REGELIDENTIFIKATOR = "regelIdentifikator"
-        val AVKORTET_GRUNNLAG = "avkortet"
-        val UAVKORTET_GRUNNLAG = "uavkortet"
-        val BEREGNINGSREGEL = "beregningsregel"
-        val HAR_AVKORTET = "harAvkortet"
+        const val SPORINGSID = "sporingsId"
+        const val SUBSUMSJONSID = "subsumsjonsId"
+        const val REGELIDENTIFIKATOR = "regelIdentifikator"
+        const val AVKORTET_GRUNNLAG = "avkortet"
+        const val UAVKORTET_GRUNNLAG = "uavkortet"
+        const val BEREGNINGSREGEL = "beregningsregel"
+        const val HAR_AVKORTET = "harAvkortet"
+        const val GRUNNBELØP_BRUKT = "grunnbeløpBrukt"
     }
 
     fun toMap(): Map<String, Any> {
@@ -31,7 +33,8 @@ data class GrunnlagResultat(
             AVKORTET_GRUNNLAG to avrundetAvkortet,
             UAVKORTET_GRUNNLAG to avrundetUavkortet,
             BEREGNINGSREGEL to beregningsregel,
-            HAR_AVKORTET to harAvkortet
+            HAR_AVKORTET to harAvkortet,
+            GRUNNBELØP_BRUKT to grunnbeløpBrukt
         )
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/regel/grunnlag/GrunnlagResultatTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/grunnlag/GrunnlagResultatTest.kt
@@ -9,13 +9,15 @@ class GrunnlagResultatTest {
     @Test
     fun `toMap skal returnere rett resultat`() {
         val grunnlagResultat = GrunnlagResultat(
-            "111",
-            "222",
-            "Grunnlag.v1",
-            4455.toBigDecimal(),
-            1122.toBigDecimal(),
-            "ORDINÆR",
-            true)
+            sporingsId = "111",
+            subsumsjonsId = "222",
+            regelidentifikator = "Grunnlag.v1",
+            avkortetGrunnlag = 4455.toBigDecimal(),
+            uavkortetGrunnlag = 1122.toBigDecimal(),
+            beregningsregel = "ORDINÆR",
+            harAvkortet = true,
+            grunnbeløpBrukt = 123.toBigDecimal()
+        )
 
         assertEquals("111", grunnlagResultat.sporingsId)
         assertEquals("222", grunnlagResultat.subsumsjonsId)
@@ -29,13 +31,15 @@ class GrunnlagResultatTest {
     @Test
     fun `getAvrundetUavkortet skal avrunde det uavkortede resultatet riktig`() {
         val grunnlagResultat = GrunnlagResultat(
-            "123",
-            "123",
-            "Grunnlag.v1",
-            1234.5678.toBigDecimal(),
-            100.499.toBigDecimal(),
-            "ORDINÆR",
-            false)
+            sporingsId = "123",
+            subsumsjonsId = "123",
+            regelidentifikator = "Grunnlag.v1",
+            avkortetGrunnlag = 1234.5678.toBigDecimal(),
+            uavkortetGrunnlag = 100.499.toBigDecimal(),
+            beregningsregel = "ORDINÆR",
+            harAvkortet = false,
+            grunnbeløpBrukt = 123.toBigDecimal()
+        )
 
         assertEquals(100.toBigDecimal(), grunnlagResultat.avrundetUavkortet)
     }
@@ -43,13 +47,15 @@ class GrunnlagResultatTest {
     @Test
     fun `getAvrundetAvkortet skal avrunde det avkortede resultatet riktig`() {
         val grunnlagResultat = GrunnlagResultat(
-            "123",
-            "123",
-            "Grunnlag.v1",
-            1234.5678.toBigDecimal(),
-            100.499.toBigDecimal(),
-            "ORDINÆR",
-            false)
+            sporingsId = "123",
+            subsumsjonsId = "123",
+            regelidentifikator = "Grunnlag.v1",
+            avkortetGrunnlag = 1234.5678.toBigDecimal(),
+            uavkortetGrunnlag = 100.499.toBigDecimal(),
+            beregningsregel = "ORDINÆR",
+            harAvkortet = false,
+            grunnbeløpBrukt = 123.toBigDecimal()
+        )
 
         assertEquals(1235.toBigDecimal(), grunnlagResultat.avrundetAvkortet)
     }


### PR DESCRIPTION
We should preserve as much data about our surroundings as possible when we run rules and calculations. Preferably the entire `Fakta` object should be added, but this is a quickfix to at least ensure the grunnbeløp is taken into account.