### PR TITLE
Viderefører pandemiregler til ut februar 2022

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/beregning/GrunnlagBeregning.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/beregning/GrunnlagBeregning.kt
@@ -41,7 +41,7 @@ internal class HovedBeregning : GrunnlagBeregning("Hoved") {
     }
 }
 
-fun LocalDate.erKoronaPeriode() = this in (LocalDate.of(2020, 3, 20)..LocalDate.of(2021, 3, 31))
+fun LocalDate.erKoronaPeriode() = this in (LocalDate.of(2020, 3, 20)..LocalDate.of(2022, 2, 28))
 
 fun Collection<BeregningsResultat>.finnHøyesteAvkortetVerdi() =
     this.maxWithOrNull(PresedensOverManueltGrunnlag() then PresedensOverVernepliktHvisAvkortertVerdiErLik())

--- a/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/beregning/GrunnlagEtterLærlingForskrift.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/beregning/GrunnlagEtterLærlingForskrift.kt
@@ -3,10 +3,7 @@ package no.nav.dagpenger.regel.grunnlag.beregning
 import no.nav.dagpenger.events.inntekt.v1.InntektKlasse
 import no.nav.dagpenger.events.inntekt.v1.sumInntekt
 import no.nav.dagpenger.regel.grunnlag.Fakta
-import java.lang.RuntimeException
 import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.Month
 import java.util.EnumSet
 
 abstract class GrunnlagEtterLærlingForskrift(
@@ -15,14 +12,8 @@ abstract class GrunnlagEtterLærlingForskrift(
     private val inntektKlasser: EnumSet<InntektKlasse>
 ) : GrunnlagBeregning(regelIdentifikator) {
 
-    companion object {
-        private val fom = LocalDate.of(2020, Month.MARCH, 20)
-        private val tom = LocalDate.of(2021, Month.DECEMBER, 31)
-        private val periode = fom..tom
-    }
-
     override fun isActive(fakta: Fakta): Boolean {
-        val erInnenforRegelverksperiode = fakta.regelverksdato in periode
+        val erInnenforRegelverksperiode = fakta.regelverksdato.erKoronaPeriode()
         return fakta.lærling && erInnenforRegelverksperiode && fakta.manueltGrunnlag == null && fakta.forrigeGrunnlag == null
     }
 

--- a/src/test/kotlin/no/nav/dagpenger/regel/grunnlag/beregning/EtterLærlingForskriftTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/grunnlag/beregning/EtterLærlingForskriftTest.kt
@@ -27,7 +27,7 @@ internal class EtterLærlingForskriftTest() {
     }
 
     @Test
-    fun ` Beregning er aktiv til fra 20 mars 2020 til 31 desember 2021`() {
+    fun ` Beregning er aktiv til fra 20 mars 2020 til 28 februar 2022`() {
 
         val fakta = Fakta(
             inntekt = null,
@@ -38,9 +38,9 @@ internal class EtterLærlingForskriftTest() {
         )
 
         assertTrue(beregning.isActive(fakta))
-        assertTrue(beregning.isActive(fakta.copy(regelverksdato = LocalDate.of(2021, 12, 31))))
+        assertTrue(beregning.isActive(fakta.copy(regelverksdato = LocalDate.of(2022, 2, 28))))
         assertFalse(beregning.isActive(fakta.copy(regelverksdato = LocalDate.of(2020, 2, 29))))
-        assertFalse(beregning.isActive(fakta.copy(regelverksdato = LocalDate.of(2022, 1, 1))))
+        assertFalse(beregning.isActive(fakta.copy(regelverksdato = LocalDate.of(2022, 3, 1))))
     }
 
     @Test
@@ -232,7 +232,7 @@ internal class EtterLærlingForskriftTest() {
             verneplikt = false,
             fangstOgFisk = true,
             lærling = true,
-            beregningsdato = LocalDate.now()
+            beregningsdato = LocalDate.of(2021, 5, 1)
         )
 
         assertSoftly {


### PR DESCRIPTION
Endret slit at koraonaperioden kun er definert ett sted i koden.

navikt/dagpenger#1000

Co-authored-by: Geir André Lund <geir.andre.lund@nav.no>