### PR TITLE
gjusteringtest/2022

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -43,7 +43,7 @@ object Dagpenger {
             const val client = "com.github.navikt.dp-biblioteker:soap-client:$version"
         }
     }
-    const val Grunnbeløp = "com.github.navikt:dp-grunnbelop:2021.06.25-11.51.bdc7c826c404"
+    const val Grunnbeløp = "com.github.navikt:dp-grunnbelop:2022.04.25-08.32.f0b301fea096"
     const val Streams = "com.github.navikt:dagpenger-streams:2021.12.29-13.08.7857ff52b457"
     const val Events = "com.github.navikt:dagpenger-events:2021.12.14-09.45.e24e8c813b27"
 }

--- a/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/Configuration.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/Configuration.kt
@@ -4,7 +4,6 @@ import com.natpryce.konfig.ConfigurationMap
 import com.natpryce.konfig.ConfigurationProperties.Companion.systemProperties
 import com.natpryce.konfig.EnvironmentVariables
 import com.natpryce.konfig.Key
-import com.natpryce.konfig.booleanType
 import com.natpryce.konfig.intType
 import com.natpryce.konfig.overriding
 import com.natpryce.konfig.stringType
@@ -26,7 +25,6 @@ private val devProperties = ConfigurationMap(
     mapOf(
         "application.profile" to Profile.DEV.toString(),
         "application.httpPort" to "8080",
-        "feature.gjustering" to false.toString(),
         "unleash.url" to "https://unleash.nais.io/api/"
     )
 )
@@ -66,10 +64,6 @@ data class Configuration(
         val profile: Profile = config()[Key("application.profile", stringType)].let { Profile.valueOf(it) },
         val httpPort: Int = config()[Key("application.httpPort", intType)],
         val unleashUrl: String = config()[Key("unleash.url", stringType)]
-    )
-
-    val features = mapOf(
-        "gjustering" to config().getOrElse(Key("feature.gjustering", booleanType), false)
     )
 }
 

--- a/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/Fakta.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/grunnlag/Fakta.kt
@@ -70,7 +70,7 @@ data class Fakta(
 }
 
 internal fun isThisGjusteringTest(regelverksdato: LocalDate): Boolean {
-    val gVirkning = LocalDate.of(2021, 5, 1)
+    val gVirkning = LocalDate.of(2022, 4, 3)
     val isRegelverksdatoAfterGjustering = regelverksdato.isAfter(gVirkning.minusDays(1))
     return Grunnlag.unleash.isEnabled(GJUSTERING_TEST) && isRegelverksdatoAfterGjustering
 }

--- a/src/test/kotlin/no/nav/dagpenger/regel/grunnlag/beregning/EtterLærlingForskriftTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/grunnlag/beregning/EtterLærlingForskriftTest.kt
@@ -9,6 +9,7 @@ import no.nav.dagpenger.events.inntekt.v1.KlassifisertInntekt
 import no.nav.dagpenger.events.inntekt.v1.KlassifisertInntektMåned
 import no.nav.dagpenger.regel.grunnlag.Fakta
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -248,6 +249,7 @@ internal class EtterLærlingForskriftTest() {
     }
 
     @Test
+    @Disabled("Skjonner ikke denne testen ass. Feiler fordi det ikke lengre er koronaperiode?")
     fun `Ingen inntekt gir ingen grunnlag for arbeidsinntekt `() {
 
         val fakta = Fakta(

--- a/src/test/kotlin/no/nav/dagpenger/regel/grunnlag/beregning/EtterLærlingForskriftTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/grunnlag/beregning/EtterLærlingForskriftTest.kt
@@ -9,7 +9,6 @@ import no.nav.dagpenger.events.inntekt.v1.KlassifisertInntekt
 import no.nav.dagpenger.events.inntekt.v1.KlassifisertInntektMåned
 import no.nav.dagpenger.regel.grunnlag.Fakta
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -249,7 +248,6 @@ internal class EtterLærlingForskriftTest() {
     }
 
     @Test
-    @Disabled("Skjonner ikke denne testen ass. Feiler fordi det ikke lengre er koronaperiode?")
     fun `Ingen inntekt gir ingen grunnlag for arbeidsinntekt `() {
 
         val fakta = Fakta(
@@ -257,7 +255,7 @@ internal class EtterLærlingForskriftTest() {
             verneplikt = false,
             fangstOgFisk = false,
             lærling = true,
-            beregningsdato = LocalDate.now()
+            beregningsdato = LocalDate.of(2022, 3, 30)
         )
 
         assertSoftly {


### PR DESCRIPTION
Utifra denne infoen: 
 
Ny G og Hengende G = 111000
Dato for ny G = Søndag 03.04.2022
Dato for Hengende G = 25.04.2022

Fjerna config, da gjustering tydeligvis toggles av/på via Unleash: 
https://unleash.nais.io/#/features/strategies/dp-g-justeringstest

En test som som jeg tror feiler pga slutt på Korona. Lurer bare på om den skal verifisere at resultat er "IngenBeregningsResultat" 